### PR TITLE
Fix procfetch#124: use --prefix instead of -C

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 | :---     |   :---: | :---: |---:
 | reduce | Command line URL shortener using reduced.to API | [reduce](https://github.com/TanmayPatil105/reduce) | v0.0.5
 | wifi-cli   | Wi-fi through command line | [wifi](https://github.com/TanmayPatil105/wifi-cli) | v0.0.2
-| procfetch  | A command-line system information utility written in C++ | [procfetch](https://github.com/TanmayPatil105/procfetch) | v0.1.2
+| procfetch  | A command-line system information utility written in C++ | [procfetch](https://github.com/TanmayPatil105/procfetch) | v0.2.0
 
 
 ### Tappping

--- a/procfetch.rb
+++ b/procfetch.rb
@@ -4,16 +4,13 @@ class Procfetch < Formula
     url "https://github.com/TanmayPatil105/procfetch/archive/refs/tags/v0.2.0.tar.gz"
     sha256 "8c8721a51440d70bb30b031f2a55ee27a82494e71de5c8d9be70ab586c1b9ed5"
     license "GPL-3.0"
-    
+
     def install
-      system "./configure"
-      system "make"
-      system "sudo mkdir -p /usr/share/procfetch/ascii"
-      system "sudo cp ascii/* /usr/share/procfetch/ascii"
-      bin.install "src/procfetch"
+      system "./configure", "--prefix=#{prefix}"
+      system "make", "install"
     end
   
     test do
       system "procfetch -t"
     end
-  end
+end


### PR DESCRIPTION
## Description

call the `configure` with `--prefix` instead of -C.

## Related Issue
* TanmayPatil105/procfetch#124
 